### PR TITLE
feat: Improved Ctrl+{Left, Right} behavior

### DIFF
--- a/lemma/use_cases/use_cases.py
+++ b/lemma/use_cases/use_cases.py
@@ -617,7 +617,13 @@ class UseCases():
     def jump_left(do_selection=False):
         document = WorkspaceRepo.get_workspace().get_active_document()
 
-        insert = document.get_insert_node()
+        original_insert = document.get_insert_node()
+        insert = original_insert
+        while insert != None and NodeTypeDB.is_whitespace(insert):
+            insert_prev = insert.prev_no_descent()
+            if insert_prev == insert:
+                break
+            insert = insert_prev
         selection = document.get_selection_node()
 
         insert_prev = insert.prev_in_parent()
@@ -625,10 +631,6 @@ class UseCases():
             insert_new = insert_prev.word_bounds()[0]
         else:
             insert_new = insert.prev_no_descent()
-            while insert_new != None and NodeTypeDB.is_whitespace(insert_new) and insert_new.prev_no_descent() != insert_new:
-                insert_new = insert_new.prev_no_descent()
-            if insert_new != None and insert_new.type == 'char' and not NodeTypeDB.is_whitespace(insert_new):
-                insert_new = insert_new.word_bounds()[0]
 
         if do_selection:
             document.set_insert_and_selection_node(insert_new, selection)
@@ -637,7 +639,7 @@ class UseCases():
         else:
             document.set_insert_and_selection_node(insert_new)
         document.update_implicit_x_position()
-        if insert != document.get_insert_node():
+        if original_insert != document.get_insert_node():
             document.scroll_insert_on_screen(ApplicationState.get_value('document_view_height'), animation_type='default')
 
         DocumentRepo.update(document)
@@ -669,17 +671,19 @@ class UseCases():
     def jump_right(do_selection=False):
         document = WorkspaceRepo.get_workspace().get_active_document()
 
-        insert = document.get_insert_node()
+        original_insert = document.get_insert_node()
+        insert = original_insert
+        while insert != None and NodeTypeDB.is_whitespace(insert):
+            insert_next = insert.next_no_descent()
+            if insert_next == insert:
+                break
+            insert = insert_next
         selection = document.get_selection_node()
 
         if insert != None and insert.type == 'char' and not NodeTypeDB.is_whitespace(insert):
             insert_new = insert.word_bounds()[1]
         else:
             insert_new = insert.next_no_descent()
-            while insert_new != None and NodeTypeDB.is_whitespace(insert_new) and insert_new.next_no_descent() != insert_new:
-                insert_new = insert_new.next_no_descent()
-            if insert_new != None and not NodeTypeDB.is_whitespace(insert_new):
-                insert_new = insert_new.word_bounds()[1]
 
         if do_selection:
             document.set_insert_and_selection_node(insert_new, selection)
@@ -688,7 +692,7 @@ class UseCases():
         else:
             document.set_insert_and_selection_node(insert_new)
         document.update_implicit_x_position()
-        if insert != document.get_insert_node():
+        if original_insert != document.get_insert_node():
             document.scroll_insert_on_screen(ApplicationState.get_value('document_view_height'), animation_type='default')
 
         DocumentRepo.update(document)

--- a/lemma/use_cases/use_cases.py
+++ b/lemma/use_cases/use_cases.py
@@ -6,12 +6,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
@@ -625,6 +625,10 @@ class UseCases():
             insert_new = insert_prev.word_bounds()[0]
         else:
             insert_new = insert.prev_no_descent()
+            while insert_new != None and NodeTypeDB.is_whitespace(insert_new) and insert_new.prev_no_descent() != insert_new:
+                insert_new = insert_new.prev_no_descent()
+            if insert_new != None and insert_new.type == 'char' and not NodeTypeDB.is_whitespace(insert_new):
+                insert_new = insert_new.word_bounds()[0]
 
         if do_selection:
             document.set_insert_and_selection_node(insert_new, selection)
@@ -672,6 +676,10 @@ class UseCases():
             insert_new = insert.word_bounds()[1]
         else:
             insert_new = insert.next_no_descent()
+            while insert_new != None and NodeTypeDB.is_whitespace(insert_new) and insert_new.next_no_descent() != insert_new:
+                insert_new = insert_new.next_no_descent()
+            if insert_new != None and not NodeTypeDB.is_whitespace(insert_new):
+                insert_new = insert_new.word_bounds()[1]
 
         if do_selection:
             document.set_insert_and_selection_node(insert_new, selection)
@@ -1057,5 +1065,3 @@ class UseCases():
         document.scroll_to_xy(x, y, 'decelerate')
 
         MessageBus.add_message('document_changed')
-
-


### PR DESCRIPTION
This PR modifies the behavior of Ctrl+{Left Arrow, Right Arrow} shortcuts to be more in-line with other text editors and the GNOME Accessibility guidelines (did not find a more up-to-date document that discusses this behavior in detail): https://wiki.gnome.org/Accessibility%282f%29Documentation%282f%29GNOME2%282f%29TestingForAccessibility.html

Now the behavior follows those rules:

- Ctrl+Left: move caret to the start of the current word, then to the start of the previous word on repeat
- Ctrl+Right: move caret to the end of the current word, then to the end of the next word on repeat

**Current behavior:**

https://github.com/user-attachments/assets/a9699831-c37d-4dbe-a0d9-5767d10571c1

**Proposed behavior:**

https://github.com/user-attachments/assets/1f1ce2de-ce2d-4113-8dd7-e16f522df87c


I think not treating spaces as separate words essentially makes this behavior much more intuitive and efficient.
